### PR TITLE
Add packages and instructions for building gcc

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ required to build codethink-toolchain
 The script assume the CentOS 6.x VM is accessible by ssh client using
 root and its password.
 
+The script will create a rpm_omnibus user which meant to be used to
+configure the installed packages and run the builds.
+
 NOTE: This script has been tested in CentOS 6.6 and 6.8 VMs.
 
 You could find CentOS ISO images in:

--- a/build-gcc-configuration-files/README
+++ b/build-gcc-configuration-files/README
@@ -1,0 +1,24 @@
+Instructions to build gcc manually (no omnibus package)
+======================================================
+
+You will need gmp, mpfr and mpc to build gcc and then tell gcc where to find it
+building the omnibus package will do this for you (remembers that this will build
+gcc too but we are looking for developing and testing gcc in a separate tree):
+
+  git clone https://github.com/CodethinkLabs/omnibus-codethink-toolchain.git
+  cd omnibus-codethink-toolchain
+  omnibus build codethink-toolchain --override base_dir:./local workers:8
+
+After gathering all the required packages we need to tell gcc where these packages are
+and for that we will need to use the gcc-configure-sourceme file:
+
+  git clone https://github.com/CodethinkLabs/gcc.git
+  cd gcc
+  git checkout codethink/$BRANCH_TO_BUILD
+  cd /home/rpm_omnibus/build-gcc
+  source gcc-configure-sourceme
+  ../gcc/configure --prefix=/home/rpm_omnibus/build-gcc --enable-languages=c,c++,fortran --with-pkgversion=codethink-toolchain --disable-bootstrap --disable-nls
+  make -j 8
+
+If you would like to run gcc tests, after building you can run
+  make -j 8 check (make -k check will remove the issue of not having autogen)

--- a/build-gcc-configuration-files/gcc-configure-sourceme
+++ b/build-gcc-configuration-files/gcc-configure-sourceme
@@ -1,0 +1,14 @@
+# This file does configure the environment variables
+# required to build gcc and run make check to run the tests.
+#
+# To configure gcc to be built or run `make check` please
+# run `source gcc-configure-sourceme` before running your
+# `configure` command when building gcc.
+export CFLAGS="-I/opt/codethink-toolchain/include -O2"
+export CPPFLAGS="-I/opt/codethink-toolchain/include -O2"
+export CXXFLAGS="-I/opt/codethink-toolchain/include -O2"
+export LDFLAGS="-Wl,-rpath,/opt/codethink-toolchain/lib -L/lib64 -L/lib -L/opt/codethink-toolchain/lib64 -L/opt/codethink-toolchain/lib"
+export LD_RUN_PATH="/lib64:/lib:/opt/codethink-toolchain/embedded/lib:/opt/codethink-toolchain/lib64:/opt/codethink-toolchain/lib"
+export PATH="/opt/rh/devtoolset-7/root/usr/bin:/opt/codethink-toolchain/bin:/opt/codethink-toolchain/embedded/bin:/home/rpm_omnibus/rvm/gems/ruby-2.2.0/bin:/home/rpm_omnibus/rvm/gems/ruby-2.2.0@global/bin:/home/rpm_omnibus/rvm/rubies/ruby-2.2.0/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:/home/rpm_omnibus/rvm/bin:/home/rpm_omnibus/bin:/home/rpm_omnibus/gem/ruby/2.2.0/bin"
+export PKG_CONFIG_PATH="/opt/codethink-toolchain/embedded/lib/pkgconfig"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/lib64:/lib:/opt/codethink-toolchain/lib64:/opt/codethink-toolchain/lib"

--- a/flang-vm.yml
+++ b/flang-vm.yml
@@ -1,15 +1,6 @@
 ---
 - hosts: GCCVM
   tasks:
-  - name: Install epel-repository and centos-release-scl
-    yum:
-      name: "{{ item }}"
-      state: latest
-    become: true
-    with_items:
-    - epel-release
-    - centos-release-scl
-
   - name: Install packages required to build flang
     yum:
       name: "{{ item }}"
@@ -17,7 +8,6 @@
     become: true
     with_items:
     - cmake3
-    - devtoolset-7
     - python27
 
   - name: Create directories in /opt
@@ -33,13 +23,12 @@
     - codethink-clang
     - codethink-flang
 
-  - name: Append enable scl software in bash_profile
+  - name: Append enable scl python software in bash_profile
     lineinfile:
       dest: /home/rpm_omnibus/.bash_profile
       state: present
       line: 'source scl_source enable {{ item }}'
     with_items:
-    - devtoolset-7
     - python27
 
   - name: Append flang library to LD_LIBRARY_PATH

--- a/gcc-vm.yml
+++ b/gcc-vm.yml
@@ -17,7 +17,15 @@
       update_cache: yes
     become: true
 
-  - name: Install packages required to create gcc rpm with omnibus
+  - name: Install centos-release-scl
+    yum:
+      name: "{{ item }}"
+      state: latest
+    become: true
+    with_items:
+    - centos-release-scl
+
+  - name: Install packages required to build and test gcc
     yum:
       name: "{{ item }}"
       state: latest
@@ -25,6 +33,18 @@
     - rpm-build
     - glibc-devel.i686
     - libgcc.i686
+    - texinfo
+    - libstdc++.i686
+    - dejagnu
+    - devtoolset-7
+    - epel-release
+    become: true
+
+  - name: Install autogen, required for testing gcc
+    yum:
+      name: autogen
+      enablerepo: epel-testing
+      state: latest
     become: true
 
   - name: Remove repository (and clean up left-over metadata)
@@ -138,3 +158,22 @@
     environment:
       PATH: '$PATH:{{add_to_PATH}}:/usr/bin:/bin:/usr/local/bin'
       GEM_PATH: '$GEM_PATH:{{ruby_gem_path}}'
+
+  - name: Copy configuration file for building/testing gcc
+    copy:
+      src: "build-gcc-configuration-files/{{ item }}"
+      dest: /home/rpm_omnibus/build-gcc/
+      owner: rpm_omnibus
+      group: rpm_omnibus
+      mode: 0644
+    with_items:
+    - gcc-configure-sourceme
+    - README
+
+  - name: Append enable scl devtoolset-7 in bash_profile
+    lineinfile:
+      dest: /home/rpm_omnibus/.bash_profile
+      state: present
+      line: 'source scl_source enable {{ item }}'
+    with_items:
+    - devtoolset-7


### PR DESCRIPTION
This packages are required to build and test gcc with make and make
check.
It does include a file to set up the environmet for building gcc
manually and a README with the instructions to follow to do this.