### PR TITLE
Replace codethink-toolchain by codethink-gcc

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Documentation
 =============
 This repository provides a bash script (provision-VM.sh) which calls two
 playbooks to configure a CentOS 6.x VM with the packages and configuration
-required to build codethink-toolchain
+required to build the packages in omnibus-codethink-toolchain
 (https://github.com/CodethinkLabs/omnibus-codethink-toolchain).
 
 The script assume the CentOS 6.x VM is accessible by ssh client using

--- a/build-gcc-configuration-files/README
+++ b/build-gcc-configuration-files/README
@@ -7,7 +7,7 @@ gcc too but we are looking for developing and testing gcc in a separate tree):
 
   git clone https://github.com/CodethinkLabs/omnibus-codethink-toolchain.git
   cd omnibus-codethink-toolchain
-  omnibus build codethink-toolchain --override base_dir:./local workers:8
+  omnibus build codethink-gcc --override base_dir:./local workers:8
 
 After gathering all the required packages we need to tell gcc where these packages are
 and for that we will need to use the gcc-configure-sourceme file:
@@ -17,7 +17,7 @@ and for that we will need to use the gcc-configure-sourceme file:
   git checkout codethink/$BRANCH_TO_BUILD
   cd /home/rpm_omnibus/build-gcc
   source gcc-configure-sourceme
-  ../gcc/configure --prefix=/home/rpm_omnibus/build-gcc --enable-languages=c,c++,fortran --with-pkgversion=codethink-toolchain --disable-bootstrap --disable-nls
+  ../gcc/configure --prefix=/home/rpm_omnibus/build-gcc --enable-languages=c,c++,fortran --with-pkgversion=codethink-gcc --disable-bootstrap --disable-nls
   make -j 8
 
 If you would like to run gcc tests, after building you can run

--- a/build-gcc-configuration-files/gcc-configure-sourceme
+++ b/build-gcc-configuration-files/gcc-configure-sourceme
@@ -4,11 +4,11 @@
 # To configure gcc to be built or run `make check` please
 # run `source gcc-configure-sourceme` before running your
 # `configure` command when building gcc.
-export CFLAGS="-I/opt/codethink-toolchain/include -O2"
-export CPPFLAGS="-I/opt/codethink-toolchain/include -O2"
-export CXXFLAGS="-I/opt/codethink-toolchain/include -O2"
-export LDFLAGS="-Wl,-rpath,/opt/codethink-toolchain/lib -L/lib64 -L/lib -L/opt/codethink-toolchain/lib64 -L/opt/codethink-toolchain/lib"
-export LD_RUN_PATH="/lib64:/lib:/opt/codethink-toolchain/embedded/lib:/opt/codethink-toolchain/lib64:/opt/codethink-toolchain/lib"
-export PATH="/opt/rh/devtoolset-7/root/usr/bin:/opt/codethink-toolchain/bin:/opt/codethink-toolchain/embedded/bin:/home/rpm_omnibus/rvm/gems/ruby-2.2.0/bin:/home/rpm_omnibus/rvm/gems/ruby-2.2.0@global/bin:/home/rpm_omnibus/rvm/rubies/ruby-2.2.0/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:/home/rpm_omnibus/rvm/bin:/home/rpm_omnibus/bin:/home/rpm_omnibus/gem/ruby/2.2.0/bin"
-export PKG_CONFIG_PATH="/opt/codethink-toolchain/embedded/lib/pkgconfig"
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/lib64:/lib:/opt/codethink-toolchain/lib64:/opt/codethink-toolchain/lib"
+export CFLAGS="-I/opt/codethink-gcc/include -O2"
+export CPPFLAGS="-I/opt/codethink-gcc/include -O2"
+export CXXFLAGS="-I/opt/codethink-gcc/include -O2"
+export LDFLAGS="-Wl,-rpath,/opt/codethink-gcc/lib -L/lib64 -L/lib -L/opt/codethink-gcc/lib64 -L/opt/codethink-gcc/lib"
+export LD_RUN_PATH="/lib64:/lib:/opt/codethink-gcc/embedded/lib:/opt/codethink-gcc/lib64:/opt/codethink-gcc/lib"
+export PATH="/opt/rh/devtoolset-7/root/usr/bin:/opt/codethink-gcc/bin:/opt/codethink-gcc/embedded/bin:/home/rpm_omnibus/rvm/gems/ruby-2.2.0/bin:/home/rpm_omnibus/rvm/gems/ruby-2.2.0@global/bin:/home/rpm_omnibus/rvm/rubies/ruby-2.2.0/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:/home/rpm_omnibus/rvm/bin:/home/rpm_omnibus/bin:/home/rpm_omnibus/gem/ruby/2.2.0/bin"
+export PKG_CONFIG_PATH="/opt/codethink-gcc/embedded/lib/pkgconfig"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/lib64:/lib:/opt/codethink-gcc/lib64:/opt/codethink-gcc/lib"

--- a/gcc-vm.yml
+++ b/gcc-vm.yml
@@ -114,9 +114,9 @@
       group: rpm_omnibus
       mode: 0775
 
-  - name: Create /opt/codethink-toolchain
+  - name: Create /opt/codethink-gcc
     file:
-      path: "/opt/codethink-toolchain"
+      path: "/opt/codethink-gcc"
       state: directory
       owner: rpm_omnibus
       group: rpm_omnibus

--- a/provision-VM.sh
+++ b/provision-VM.sh
@@ -8,7 +8,7 @@ usage() {
 
   This script installs the required software and configures the VM,
   described by its VM_IP_ADDRESS passed as argument to be able to
-  build the codethink-toolchain repository.
+  build the packages in omnibus-codethink-toolchain repository.
   (https://github.com/CodethinkLabs/omnibus-codethink-toolchain).
 
   OPTIONS:


### PR DESCRIPTION
codethink-toolchain is not longer a recogniced name in the
omnibus-codethink-toolchain repository. It has been replaced
by codethink-gcc to match the rest of the packages built with
omnibus.